### PR TITLE
Fix: `actorId` -> `id`

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,7 +13,7 @@ const App = () => {
   // State of the input component.
   const [greetingMessage, setGreetingMessage] = useState("Hello, Resemble!");
 
-  const { useGreetings } = Greeter({ actorId: GREETER_ID });
+  const { useGreetings } = Greeter({ id: GREETER_ID });
   const {
     response,
     mutations: { Greet },


### PR DESCRIPTION
The example was broken due to the recent release of a new version of `reboot-resemble-cli`, which generates a different API.